### PR TITLE
Feature/#17

### DIFF
--- a/tools/get_data_length_stat.py
+++ b/tools/get_data_length_stat.py
@@ -2,21 +2,28 @@ import argparse
 from pathlib import Path
 import numpy as np
 import pandas as pd
+from transformers import AutoTokenizer
 
 def define_argparser() -> argparse.Namespace:
     parser = argparse.ArgumentParser()
     
     parser.add_argument('--input_path', type=Path, required=True)
     parser.add_argument('--output_path', type=Path, required=True)
-    parser.add_argument('--tokenizer', type=str, choices=['character', 'word'], default="word")
-    
+    parser.add_argument('--tokenizer', type=str, default="word", 
+                        help="You can choose any tokenizer applied in huggingface model (https://huggingface.co/models) by feeding name of huggingface model. \
+                        Otherwise, you can simply use word-based or character-based tokenizer by feeding 'word' or 'character'. Defaults to 'word'.")
+
     return parser.parse_args()
 
 def apply_tokenizer(each_type_data: pd.Series, tokenizer: str) -> pd.Series:
     if tokenizer == 'word':
         return each_type_data.apply(lambda x: len(x.split(' ')))
-    else:
+    elif tokenizer == 'character':
         return each_type_data.apply(lambda x: x.replace(' ', '')).apply(len)
+    else:
+        tokenizer = AutoTokenizer.from_pretrained(tokenizer, bos_token='</s>', eos_token='</s>',
+                                                  unk_token='<unk>', pad_token='<pad>', mask_token='<mask>')
+        return each_type_data.apply(lambda x: len(tokenizer.tokenize(x)))
 
 def data_stats_to_excel(input_path: Path, output_path: Path, tokenizer: str) -> None:
     """
@@ -37,7 +44,9 @@ def data_stats_to_excel(input_path: Path, output_path: Path, tokenizer: str) -> 
     Args:
         input_path (str): the path and filename of dataset to analyse.
         output_path (str): the path and filename for data length statistics output.
-        tokenizer (str, optional): tokenizer options from ('character', 'word'). Defaults to 'word'.
+        tokenizer (str, optional): tokenizer options from ('word', 'character', 'huggingface_model_name').
+                                  'huggingface_model_name' means the name of huggingface model (e.g. 'bert-base-multilingual-cased')
+                                   to get the model's tokenizer. Defaults to 'word'.
     """
     
     # load data

--- a/tools/get_data_length_stat.py
+++ b/tools/get_data_length_stat.py
@@ -21,9 +21,8 @@ def apply_tokenizer(each_type_data: pd.Series, tokenizer: str) -> pd.Series:
     elif tokenizer == 'character':
         return each_type_data.apply(lambda x: x.replace(' ', '')).apply(len)
     else:
-        tokenizer = AutoTokenizer.from_pretrained(tokenizer, bos_token='</s>', eos_token='</s>',
-                                                  unk_token='<unk>', pad_token='<pad>', mask_token='<mask>')
-        return each_type_data.apply(lambda x: len(tokenizer.tokenize(x)))
+        hf_tokenizer = AutoTokenizer.from_pretrained(tokenizer)
+        return each_type_data.apply(lambda x: len(hf_tokenizer.tokenize(x)))
 
 def data_stats_to_excel(input_path: Path, output_path: Path, tokenizer: str) -> None:
     """

--- a/tools/make_boxplots.py
+++ b/tools/make_boxplots.py
@@ -60,9 +60,8 @@ def apply_tokenizer(text_data_of_each_type: pd.Series, tokenizer: str) -> pd.Ser
     elif tokenizer == 'character':
         return text_data_of_each_type.apply(lambda x: x.replace(' ', '')).apply(len)
     else:
-        tokenizer = AutoTokenizer.from_pretrained(tokenizer, bos_token='</s>', eos_token='</s>',
-                                                  unk_token='<unk>', pad_token='<pad>', mask_token='<mask>')
-        return text_data_of_each_type.apply(lambda x: len(tokenizer.tokenize(x)))
+        hf_tokenizer = AutoTokenizer.from_pretrained(tokenizer)
+        return text_data_of_each_type.apply(lambda x: len(hf_tokenizer.tokenize(x)))
 
 def make_boxplots(data: pd.DataFrame, data_type: list, output_path: Path, max_split_cnts: int = 10, tokenizer: str = 'word') -> None:
     """


### PR DESCRIPTION
- Add  auto tokenizer applied in huggingface model for data length statistics by data category

- [x] `get_data_length_stat.py`

- [x] `make_boxplots.py`

```bash
# {} : optional

### 1. Environment info
- python version: 3.9.12
- transformers version: 4.19.1

### 2. `get_data_length_stat.py`
$ python get_data_length_stat.py --input_path=[INPUT PATH] --output_path=[OUTPUT PATH] {--tokenizer=[TOKENIZER]}

# Example
$ python tools/get_data_length_stat.py \
--input_path=tools/test_data/ko_multi_lang_train_sample.xlsx \
--output_path=tools/data_statistics_tokenized_by_bert.xlsx \
--tokenizer=bert-base-multilingual-cased
```