### PR TITLE
small fix to requirements.txt

### DIFF
--- a/requirements-kor.txt
+++ b/requirements-kor.txt
@@ -3,5 +3,5 @@ fire==0.3.1
 pyyaml
 bs4
 html2text
-stdnum
+python-stdnum
 numpy


### PR DESCRIPTION
- Fixed the `requirements-kor.txt` by renaming `stdnum` to `python-stdnum`. 
- It's a small issue, so please merge this PR.