### PR TITLE
fix: return list[str] from word_tokenize instead of str

### DIFF
--- a/dps/spark/prep/japanese_prep.py
+++ b/dps/spark/prep/japanese_prep.py
@@ -17,7 +17,7 @@ tokenizer_obj = dictionary.Dictionary().create()
 
 def word_tokenize(text):
     mode = tokenizer.Tokenizer.SplitMode.C
-    tokenized_text = " ".join([m.surface() for m in tokenizer_obj.tokenize(text, mode)])
+    tokenized_text = [m.surface() for m in tokenizer_obj.tokenize(text, mode)]
     return tokenized_text
 
 


### PR DESCRIPTION
`word_tokenize` previously returned a `str`, but downstream methods assumed that the return type was a `list[str]`:

- https://github.com/EleutherAI/dps/blob/bec4078f341037879feab1d5c82668745b28aa55/dps/spark/prep/japanese_prep.py#L36-L43
- https://github.com/EleutherAI/dps/blob/bec4078f341037879feab1d5c82668745b28aa55/dps/spark/prep/japanese_prep.py#L46-L55